### PR TITLE
feat: added http.Client intercepting for mock calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,24 @@ tests := []echoprobe.Data{
 echoprobe.AssertAll(it, tests)
 ```
 
+#### Intercepting a custom `http.Client`
+
+By default, echoprobe only listens to the baseUrl on the `http.DefaultClient`.
+When using a custom `http.Client` for HTTP calls, echoprobe should be notified.
+The custom client can be added after initializing the integration tests:
+
+```go
+it := echoprobe.NewIntegrationTest(
+    t,
+    echoprobe.IntegrationTestWithMocks{
+        BaseURL: "/v1",
+    },
+)
+
+client := http.Client{Transport: &http.Transport{}}
+it.Mock.SetHttpClient(&client)
+```
+
 ### With PostgreSQL and Mocks
 
 An integration test support various types of features all at once. In order to use PostgreSQL and Mocks, you can use the following example. Similarly, you can append other options to your integration test.

--- a/echoprobe.go
+++ b/echoprobe.go
@@ -17,6 +17,7 @@ package echoprobe
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"testing"
 
 	"github.com/docker/go-connections/nat"
@@ -108,11 +109,12 @@ func (o IntegrationTestWithPostgres) tearDown(it *IntegrationTest) {
 // IntegrationTestWithMocks is an option for integration testing that allows mocking
 // The mocks should be placed in a 'mocks' directory where the _test.go file is located.
 type IntegrationTestWithMocks struct {
-	BaseURL string
+	BaseURL    string
+	HttpClient *http.Client
 }
 
 func (o IntegrationTestWithMocks) setup(it *IntegrationTest) {
-	it.Mock = NewMock(o.BaseURL)
+	it.Mock = NewMock(o.BaseURL, o.HttpClient)
 }
 
 func (o IntegrationTestWithMocks) tearDown(it *IntegrationTest) {

--- a/echoprobe.go
+++ b/echoprobe.go
@@ -17,7 +17,6 @@ package echoprobe
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"testing"
 
 	"github.com/docker/go-connections/nat"
@@ -109,12 +108,11 @@ func (o IntegrationTestWithPostgres) tearDown(it *IntegrationTest) {
 // IntegrationTestWithMocks is an option for integration testing that allows mocking
 // The mocks should be placed in a 'mocks' directory where the _test.go file is located.
 type IntegrationTestWithMocks struct {
-	BaseURL    string
-	HttpClient *http.Client
+	BaseURL string
 }
 
 func (o IntegrationTestWithMocks) setup(it *IntegrationTest) {
-	it.Mock = NewMock(o.BaseURL, o.HttpClient)
+	it.Mock = NewMock(o.BaseURL)
 }
 
 func (o IntegrationTestWithMocks) tearDown(it *IntegrationTest) {

--- a/mock.go
+++ b/mock.go
@@ -52,9 +52,6 @@ func NewMock(baseURL string) *Mock {
 // TearDown removes all the registered mocks
 func (m *Mock) TearDown() {
 	gock.Off()
-	if m.httpClient != nil {
-		gock.RestoreClient(m.httpClient)
-	}
 }
 
 // Debug is used to print the request URL and the mock returned for that particular request

--- a/mock.go
+++ b/mock.go
@@ -43,16 +43,18 @@ type Mock struct {
 }
 
 // NewMock creates a new Mock
-func NewMock(baseURL string, httpClient *http.Client) *Mock {
+func NewMock(baseURL string) *Mock {
 	return &Mock{
-		baseURL:    baseURL,
-		httpClient: httpClient,
+		baseURL: baseURL,
 	}
 }
 
 // TearDown removes all the registered mocks
 func (m *Mock) TearDown() {
 	gock.Off()
+	if m.httpClient != nil {
+		gock.RestoreClient(m.httpClient)
+	}
 }
 
 // Debug is used to print the request URL and the mock returned for that particular request
@@ -67,6 +69,10 @@ func (m *Mock) Debug() {
 			}
 		}
 	}()
+}
+
+func (m *Mock) SetHttpClient(httpClient *http.Client) {
+	m.httpClient = httpClient
 }
 
 func (m *Mock) SetJSON(response *gock.Response, config *MockConfig) {

--- a/mock.go
+++ b/mock.go
@@ -56,16 +56,17 @@ func (m *Mock) TearDown() {
 
 // Debug is used to print the request URL and the mock returned for that particular request
 func (m *Mock) Debug() {
-	gock.Observe(gock.DumpRequest)
+	gock.Observe(func(req *http.Request, mock gock.Mock) {
+		debug := fmt.Sprintf(
+			"\n-- MOCK START\n"+
+				"%s - %d \n"+
+				"%s \n"+
+				"-- MOCK END\n",
+			req.URL, mock.Response().StatusCode, string(mock.Response().BodyBuffer),
+		)
 
-	defer func() {
-		if !gock.IsDone() {
-			fmt.Println("Pending mocks:")
-			for _, mock := range gock.Pending() {
-				fmt.Printf("- %s %s\n", mock.Request().Method, mock.Request().URLStruct.String())
-			}
-		}
-	}()
+		fmt.Println(debug)
+	})
 }
 
 func (m *Mock) SetHttpClient(httpClient *http.Client) {

--- a/test/echoprobe_test.go
+++ b/test/echoprobe_test.go
@@ -69,3 +69,40 @@ func TestIntegrationHandler_Live(t *testing.T) {
 
 	echoprobe.AssertAll(it, tests)
 }
+
+func TestIntegrationHandler_MockWithHttpClient(t *testing.T) {
+	if testing.Short() {
+		t.Skip("(skipped)")
+	}
+
+	// custom http client
+	httpClient := http.Client{Transport: &http.Transport{}}
+
+	it := echoprobe.NewIntegrationTest(t, echoprobe.IntegrationTestWithMocks{
+		BaseURL:    "https://weather.com",
+		HttpClient: &httpClient,
+	})
+
+	handler := NewApiHandler(&httpClient)
+
+	tests := []echoprobe.Data{
+		{
+			Name:           "ok: Weather forecast",
+			Method:         http.MethodGet,
+			Handler:        handler.Weather,
+			ExpectCode:     http.StatusOK,
+			ExpectResponse: "weather-ok",
+			Mocks: []echoprobe.MockCall{
+				{
+					Config: &echoprobe.MockConfig{
+						UrlPath:    "/forecast/amsterdam",
+						Response:   "weather-ok",
+						StatusCode: http.StatusOK,
+					},
+				},
+			},
+		},
+	}
+
+	echoprobe.AssertAll(it, tests)
+}

--- a/test/echoprobe_test.go
+++ b/test/echoprobe_test.go
@@ -137,7 +137,7 @@ func TestIntegrationHandler_MockWeatherWithoutHttpClientConfigured(t *testing.T)
 
 	tests := []echoprobe.Data{
 		{
-			Name:       "regression: weather forecast should fail when Mock doesn't contain the custom http.Client",
+			Name:       "ok: weather forecast mock doesn't work when Mock doesn't contain the custom http.Client",
 			Method:     http.MethodGet,
 			Handler:    handler.Weather,
 			ExpectCode: http.StatusServiceUnavailable,

--- a/test/echoprobe_test.go
+++ b/test/echoprobe_test.go
@@ -79,7 +79,7 @@ func TestIntegrationHandler_MockWeatherWithCustomHttpClient(t *testing.T) {
 	httpClient := http.Client{Transport: &http.Transport{}}
 
 	it := echoprobe.NewIntegrationTest(t, echoprobe.IntegrationTestWithMocks{
-		BaseURL: "https://weather.com",
+		BaseURL: "https://weather.test",
 	})
 	it.Mock.SetHttpClient(&httpClient)
 
@@ -129,7 +129,7 @@ func TestIntegrationHandler_MockWeatherWithoutHttpClientConfigured(t *testing.T)
 	}
 
 	it := echoprobe.NewIntegrationTest(t, echoprobe.IntegrationTestWithMocks{
-		BaseURL: "https://weather.com",
+		BaseURL: "https://weather.test",
 	})
 
 	httpClient := http.Client{Transport: &http.Transport{}}

--- a/test/fixtures/mocks/weather-ok.json
+++ b/test/fixtures/mocks/weather-ok.json
@@ -1,0 +1,4 @@
+{
+  "location": "Amsterdam",
+  "summary": "Sunny, between 30 and 15 degrees celsius"
+}

--- a/test/fixtures/responses/weather-ok.json
+++ b/test/fixtures/responses/weather-ok.json
@@ -1,0 +1,4 @@
+{
+  "location": "Amsterdam",
+  "summary": "Sunny, between 30 and 15 degrees celsius"
+}

--- a/test/handlers.go
+++ b/test/handlers.go
@@ -15,6 +15,9 @@
 package test
 
 import (
+	"encoding/json"
+	"fmt"
+	"io"
 	"net/http"
 	"time"
 
@@ -78,4 +81,85 @@ func (h *Handler) Live(ctx echo.Context) error {
 		ServiceStatus: statusHealthy,
 		Description:   descriptionHealthy,
 	})
+}
+
+// WeatherForecast provides information about the weather
+type WeatherForecast struct {
+	Location ForecastLocation `json:"location"`
+	Summary  ForecastSummary  `json:"summary"`
+} // @name WeatherForecast
+
+// ForecastLocation defines the location of the weather forecast.
+type ForecastLocation string // @name forecastLocation
+
+const (
+	forecastLocation ForecastLocation = "Amsterdam"
+)
+
+// ForecastSummary the specifics of the weather forecast.
+type ForecastSummary string // @name forecastSummary
+
+const (
+	forecastSummary ForecastSummary = "Sunny, between 30 and 15 degrees celsius"
+	failedSummary   ForecastSummary = "Summary could not be loaded."
+)
+
+type ApiHandler struct {
+	HttpClient *http.Client
+}
+
+func NewApiHandler(httpClient *http.Client) *ApiHandler {
+	return &ApiHandler{
+		HttpClient: httpClient,
+	}
+}
+
+// Weather fetches the latest weather forecast for Amsterdam.
+//
+// @Summary Weather forecast
+// @Description Performs an external api call to get weather forecast
+// @Tags weather
+// @ID weather-forecast
+// @Produce json
+// @Success 200 {object} WeatherForecast "OK"
+// @Failure 503 {object} WeatherForecast "Service Unavailable"
+// @Router /weather/amsterdam [get]
+func (h *ApiHandler) Weather(ctx echo.Context) error {
+	res, err := h.HttpClient.Get("https://weather.com/forecast/amsterdam")
+	if err != nil {
+		fmt.Println(err)
+		return ctx.JSON(http.StatusServiceUnavailable, WeatherForecast{
+			Location: forecastLocation,
+			Summary:  failedSummary,
+		})
+	}
+	defer res.Body.Close()
+
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		fmt.Println("Error reading response body:", err)
+		return ctx.JSON(http.StatusServiceUnavailable, WeatherForecast{
+			Location: forecastLocation,
+			Summary:  failedSummary,
+		})
+	}
+
+	if res.StatusCode != http.StatusOK {
+		fmt.Printf("Weather API returned status: %d\n", res.StatusCode)
+		return ctx.JSON(http.StatusServiceUnavailable, WeatherForecast{
+			Location: forecastLocation,
+			Summary:  failedSummary,
+		})
+	}
+
+	var weatherData map[string]any
+	if err := json.Unmarshal(body, &weatherData); err != nil {
+		fmt.Println("Error parsing JSON:", err)
+		return ctx.JSON(http.StatusServiceUnavailable, WeatherForecast{
+			Location: forecastLocation,
+			Summary:  failedSummary,
+		})
+	}
+
+	return ctx.JSON(http.StatusOK, weatherData)
 }

--- a/test/handlers.go
+++ b/test/handlers.go
@@ -100,8 +100,7 @@ const (
 type ForecastSummary string // @name forecastSummary
 
 const (
-	forecastSummary ForecastSummary = "Sunny, between 30 and 15 degrees celsius"
-	failedSummary   ForecastSummary = "Summary could not be loaded."
+	failedSummary ForecastSummary = "Summary could not be loaded."
 )
 
 type ApiHandler struct {

--- a/test/handlers.go
+++ b/test/handlers.go
@@ -125,7 +125,9 @@ func NewApiHandler(httpClient *http.Client) *ApiHandler {
 // @Failure 503 {object} WeatherForecast "Service Unavailable"
 // @Router /weather/amsterdam [get]
 func (h *ApiHandler) Weather(ctx echo.Context) error {
-	res, err := h.HttpClient.Get("https://weather.com/forecast/amsterdam")
+	apiUrl := "https://weather.com/forecast/amsterdam"
+
+	res, err := h.HttpClient.Get(apiUrl)
 	if err != nil {
 		fmt.Println(err)
 		return ctx.JSON(http.StatusServiceUnavailable, WeatherForecast{

--- a/test/handlers.go
+++ b/test/handlers.go
@@ -16,8 +16,8 @@ package test
 
 import (
 	"encoding/json"
-	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"time"
 
@@ -129,7 +129,7 @@ func (h *ApiHandler) Weather(ctx echo.Context) error {
 
 	res, err := h.HttpClient.Get(apiUrl)
 	if err != nil {
-		fmt.Println(err)
+		log.Printf("error fetching weather: %v", err)
 		return ctx.JSON(http.StatusServiceUnavailable, WeatherForecast{
 			Location: forecastLocation,
 			Summary:  failedSummary,
@@ -139,7 +139,7 @@ func (h *ApiHandler) Weather(ctx echo.Context) error {
 
 	body, err := io.ReadAll(res.Body)
 	if err != nil {
-		fmt.Println("Error reading response body:", err)
+		log.Printf("Error reading response body: %v", err)
 		return ctx.JSON(http.StatusServiceUnavailable, WeatherForecast{
 			Location: forecastLocation,
 			Summary:  failedSummary,
@@ -147,16 +147,16 @@ func (h *ApiHandler) Weather(ctx echo.Context) error {
 	}
 
 	if res.StatusCode != http.StatusOK {
-		fmt.Printf("Weather API returned status: %d\n", res.StatusCode)
+		log.Printf("Weather API returned status: %d", res.StatusCode)
 		return ctx.JSON(http.StatusServiceUnavailable, WeatherForecast{
 			Location: forecastLocation,
 			Summary:  failedSummary,
 		})
 	}
 
-	var weatherData map[string]any
+	var weatherData WeatherForecast
 	if err := json.Unmarshal(body, &weatherData); err != nil {
-		fmt.Println("Error parsing JSON:", err)
+		log.Printf("Error parsing JSON: %v", err)
 		return ctx.JSON(http.StatusServiceUnavailable, WeatherForecast{
 			Location: forecastLocation,
 			Summary:  failedSummary,

--- a/test/handlers.go
+++ b/test/handlers.go
@@ -124,7 +124,7 @@ func NewApiHandler(httpClient *http.Client) *ApiHandler {
 // @Failure 503 {object} WeatherForecast "Service Unavailable"
 // @Router /weather/amsterdam [get]
 func (h *ApiHandler) Weather(ctx echo.Context) error {
-	apiUrl := "https://weather.com/forecast/amsterdam"
+	apiUrl := "https://weather.test/forecast/amsterdam"
 
 	res, err := h.HttpClient.Get(apiUrl)
 	if err != nil {


### PR DESCRIPTION
# One-line summary

Adding intercepting custom http.Client for Mocks while keeping the API backward compatible

## Description

Mocks were only possible for baseUrls, when using a custom http.Client (for configuration like request timeouts) MockCalls wouldn't be caught by echoprobe.

## Types of Changes
_What types of changes does your code introduce? Keep the ones that apply:_

- New feature (non-breaking change which adds functionality)
- Configuration change
- Refactor/improvements

## Tasks
_List of tasks you will do to complete the PR_
- [x] Add `gock.InterceptClient` functionality to `mock.go`
- [x] Add tests to verify that everything is functioning correctly.

## Review
_List of tasks the reviewer must do to review the PR_
- [ ] Tests
- [ ] Documentation
- [ ] CHANGELOG

## Deployment Notes
These should highlight any db migrations, feature toggles, etc.
