### PR TITLE
chore: added ImagePlatform config for BQ integration tests

### DIFF
--- a/bigquery.go
+++ b/bigquery.go
@@ -39,14 +39,15 @@ type BigqueryEmulatorContainer struct {
 	BqGrpcPort int
 }
 
-func setupBigqueryEmulator(ctx context.Context, dataPath string) (*BigqueryEmulatorContainer, error) {
+func setupBigqueryEmulator(ctx context.Context, dataPath string, imagePlatform string) (*BigqueryEmulatorContainer, error) {
 	executionPath, err := testpath()
 	if err != nil {
 		return nil, err
 	}
 
 	req := testcontainers.ContainerRequest{
-		Image: "ghcr.io/goccy/bigquery-emulator:latest",
+		Image:         "ghcr.io/goccy/bigquery-emulator:latest",
+		ImagePlatform: imagePlatform,
 		HostConfigModifier: func(config *container.HostConfig) {
 			config.Mounts = append(config.Mounts, mount.Mount{
 				Type:   mount.TypeBind,

--- a/echoprobe.go
+++ b/echoprobe.go
@@ -122,10 +122,14 @@ func (o IntegrationTestWithMocks) tearDown(it *IntegrationTest) {
 // IntegrationTestWithBigQuery is an option for integration testing that sets up a BigQuery database test container.
 type IntegrationTestWithBigQuery struct {
 	DataPath string
+	// ImagePlatform overrides the Docker image platform (e.g. "linux/amd64").
+	// Leave empty to use the Docker daemon default.
+	// Required on Apple Silicon because ghcr.io/goccy/bigquery-emulator has no arm64 manifest.
+	ImagePlatform string
 }
 
 func (o IntegrationTestWithBigQuery) setup(it *IntegrationTest) {
-	container, err := setupBigqueryEmulator(context.Background(), o.DataPath)
+	container, err := setupBigqueryEmulator(context.Background(), o.DataPath, o.ImagePlatform)
 	if err != nil {
 		it.T.Fatalf("database setup error: %v", err)
 	}


### PR DESCRIPTION
# One-line summary

Added ImagePlatform option to BigQuery test container setup to allow platform override (e.g. linux/amd64), needed for Apple Silicon where the emulator image has no arm64 manifest (which is the default).

## Types of Changes
_What types of changes does your code introduce? Keep the ones that apply:_

- New feature (non-breaking change which adds functionality)
