### PR TITLE
ci: enforce SHA1 for Github Actions

### DIFF
--- a/.github/composites/jfrog/action.yaml
+++ b/.github/composites/jfrog/action.yaml
@@ -26,7 +26,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up Artifactory CLI
-      uses: jfrog/setup-jfrog-cli@v4
+      uses: jfrog/setup-jfrog-cli@1641575d87647fb969c0545f0b6a76873e328b7c # v5.0.0
       id: jf-oidc
       env:
         JF_URL: ${{ inputs.jf_url }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -55,7 +55,7 @@ jobs:
           DRY_RUN: true # Do not push the tag during PR
 
       - name: JFrog scanning
-        uses: ingka-group/echoprobe/.github/composites/jfrog@main
+        uses: ./.github/composites/jfrog
         with:
           jf_url: ${{ secrets.JF_URL }}
           jf_oidc_provider: ${{ secrets.JF_OIDC_PROVIDER }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -38,8 +38,12 @@ jobs:
           # A state-of-the-art golang linter.
           go install honnef.co/go/tools/cmd/staticcheck@latest
 
+          # Pre-commit
+          pip install pre-commit
+
       - name: Run .pre-commit-config.yaml
-        uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
+        shell: bash
+        run: make pre-commit
 
       - name: Bump version and push tag
         uses: anothrNick/github-tag-action@4ed44965e0db8dab2b466a16da04aec3cc312fd8 # 1.75.0

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,17 +14,17 @@ jobs:
     steps:
       - name: Triage PR title
         if: ${{ startsWith(github.head_ref, 'dependabot/') != true }}
-        uses: amannn/action-semantic-pull-request@v6.1.1
+        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ github.token }}
 
       - name: Check out source code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Setup go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version-file: "go.mod"
           cache-dependency-path: "go.sum"
@@ -39,10 +39,10 @@ jobs:
           go install honnef.co/go/tools/cmd/staticcheck@latest
 
       - name: Run .pre-commit-config.yaml
-        uses: pre-commit/action@v3.0.1
+        uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
 
       - name: Bump version and push tag
-        uses: anothrNick/github-tag-action@1.75.0
+        uses: anothrNick/github-tag-action@4ed44965e0db8dab2b466a16da04aec3cc312fd8 # 1.75.0
         id: bump_version
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
           DEFAULT_BUMP: patch
 
       - name: JFrog scanning
-        uses: ingka-group/echoprobe/.github/composites/jfrog@main
+        uses: ./.github/composites/jfrog
         with:
           jf_url: ${{ secrets.JF_URL }}
           jf_oidc_provider: ${{ secrets.JF_OIDC_PROVIDER }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,18 +18,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Get latest tag
-        uses: WyriHaximus/github-action-get-previous-tag@v2.0.0
+        uses: WyriHaximus/github-action-get-previous-tag@61819f33034117e6c686e6a31dba995a85afc9de # v2.0.0
         id: previous_version
         with:
           prefix: v
 
       - name: Bump version and push tag
-        uses: anothrNick/github-tag-action@1.75.0
+        uses: anothrNick/github-tag-action@4ed44965e0db8dab2b466a16da04aec3cc312fd8 # 1.75.0
         id: bump_version
         env:
           GITHUB_TOKEN: ${{ github.token }}
@@ -51,7 +51,7 @@ jobs:
 
       - name: Build changelog
         id: build_changelog
-        uses: mikepenz/release-changelog-builder-action@v6
+        uses: mikepenz/release-changelog-builder-action@a34a8009a9588bb86b02a873cf592440e96a5da8 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
@@ -74,7 +74,7 @@ jobs:
           fi
 
       - name: Create release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
         with:
           prerelease: false
           draft: false

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ingka-group/echoprobe
 
-go 1.24.1
+go 1.26.1
 
 require (
 	github.com/docker/docker v28.5.2+incompatible


### PR DESCRIPTION
# Description

The recent supply chain attacks around GitHub Actions require us to take preventive measures in the form of pinning versions to the full SHA1 commit hashes. 

## Types of Changes
_What types of changes does your code introduce? Keep the ones that apply:_

- Refactor/improvements