### PR TITLE
feat: make container image versions configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,12 +70,13 @@ echoprobe.AssertAll(it, tests)
 
 ### With PostgreSQL
 
-To use PostgreSQL in your integration test, you need to pass the `IntegrationTestWithPostgres` option to the `NewIntegrationTest` function. _Optionally_, you can initialize your database using a SQL script, that will be executed before the test starts. The script should contain the necessary DDL and DML statements to prepare the database for the test. The script must be present under `fixtures`. For example, `fixtures/init-db.sql`.
+To use PostgreSQL in your integration test, you need to pass the `IntegrationTestWithPostgres` option to the `NewIntegrationTest` function. You can pin a specific Postgres version using the `Version` field (defaults to `17-alpine`). _Optionally_, you can initialize your database using a SQL script, that will be executed before the test starts. The script should contain the necessary DDL and DML statements to prepare the database for the test. The script must be present under `fixtures`. For example, `fixtures/init-db.sql`.
 
 ```golang
 it := echoprobe.NewIntegrationTest(
     t,
     echoprobe.IntegrationTestWithPostgres{
+        Version:       "16-alpine",
         InitSQLScript: "init-db.sql",
     },
 )
@@ -95,7 +96,7 @@ echoprobe.AssertAll(it, tests)
 
 ### With BigQuery
 
-`echoprobe` supports testing with BigQuery using `ghcr.io/goccy/bigquery-emulator` as a test contair. To use BigQuery in your integration test, you need to pass the `IntegrationTestWithBigQuery` option to the `NewIntegrationTest` function. It is expected that BigQuery needs to be populated with data upon the test startup. To do that, you need to provide a `.yaml` under the `fixtures/bigquery` directory.
+`echoprobe` supports testing with BigQuery using `ghcr.io/goccy/bigquery-emulator` as a test container. To use BigQuery in your integration test, you need to pass the `IntegrationTestWithBigQuery` option to the `NewIntegrationTest` function. You can pin a specific emulator version using the `Version` field (defaults to `latest`). It is expected that BigQuery needs to be populated with data upon the test startup. To do that, you need to provide a `.yaml` under the `fixtures/bigquery` directory.
 The YAML file should contain the necessary format so that BigQuery emulator can mount the data in the container.
 
 ```golang

--- a/bigquery.go
+++ b/bigquery.go
@@ -25,11 +25,11 @@ import (
 )
 
 const (
-	defaultBigqueryImage = "ghcr.io/goccy/bigquery-emulator:latest"
-	bqMountPath          = "/mnt/data.yaml"
-	bqHttpPort           = "9050/tcp"
-	bqGrpcPort           = "9060/tcp"
-	bqProject            = "test"
+	defaultBigqueryVersion = "latest"
+	bqMountPath            = "/mnt/data.yaml"
+	bqHttpPort             = "9050/tcp"
+	bqGrpcPort             = "9060/tcp"
+	bqProject              = "test"
 )
 
 type BigqueryEmulatorContainer struct {
@@ -40,9 +40,9 @@ type BigqueryEmulatorContainer struct {
 	BqGrpcPort int
 }
 
-func setupBigqueryEmulator(ctx context.Context, image string, dataPath string) (*BigqueryEmulatorContainer, error) {
-	if image == "" {
-		image = defaultBigqueryImage
+func setupBigqueryEmulator(ctx context.Context, version string, dataPath string) (*BigqueryEmulatorContainer, error) {
+	if version == "" {
+		version = defaultBigqueryVersion
 	}
 
 	executionPath, err := testpath()
@@ -51,7 +51,7 @@ func setupBigqueryEmulator(ctx context.Context, image string, dataPath string) (
 	}
 
 	req := testcontainers.ContainerRequest{
-		Image: image,
+		Image: "ghcr.io/goccy/bigquery-emulator:" + version,
 		HostConfigModifier: func(config *container.HostConfig) {
 			config.Mounts = append(config.Mounts, mount.Mount{
 				Type:   mount.TypeBind,

--- a/bigquery.go
+++ b/bigquery.go
@@ -25,10 +25,11 @@ import (
 )
 
 const (
-	bqMountPath = "/mnt/data.yaml"
-	bqHttpPort  = "9050/tcp"
-	bqGrpcPort  = "9060/tcp"
-	bqProject   = "test"
+	defaultBigqueryImage = "ghcr.io/goccy/bigquery-emulator:latest"
+	bqMountPath          = "/mnt/data.yaml"
+	bqHttpPort           = "9050/tcp"
+	bqGrpcPort           = "9060/tcp"
+	bqProject            = "test"
 )
 
 type BigqueryEmulatorContainer struct {
@@ -39,14 +40,18 @@ type BigqueryEmulatorContainer struct {
 	BqGrpcPort int
 }
 
-func setupBigqueryEmulator(ctx context.Context, dataPath string) (*BigqueryEmulatorContainer, error) {
+func setupBigqueryEmulator(ctx context.Context, image string, dataPath string) (*BigqueryEmulatorContainer, error) {
+	if image == "" {
+		image = defaultBigqueryImage
+	}
+
 	executionPath, err := testpath()
 	if err != nil {
 		return nil, err
 	}
 
 	req := testcontainers.ContainerRequest{
-		Image: "ghcr.io/goccy/bigquery-emulator:latest",
+		Image: image,
 		HostConfigModifier: func(config *container.HostConfig) {
 			config.Mounts = append(config.Mounts, mount.Mount{
 				Type:   mount.TypeBind,

--- a/echoprobe.go
+++ b/echoprobe.go
@@ -71,7 +71,7 @@ type IntegrationTestOption interface {
 // In the InitSQLScript a SQL script filename can be passed to initialize the database. The script should be located
 // under a 'fixtures' directory where the _test.go file is located. An optional gorm config can also be passed.
 type IntegrationTestWithPostgres struct {
-	Image         string
+	Version       string
 	InitSQLScript string
 	Config        *gorm.Config
 }
@@ -82,7 +82,7 @@ func (o IntegrationTestWithPostgres) setup(it *IntegrationTest) {
 		o.Config = &gorm.Config{}
 	}
 
-	dbContainer, err := setupPostgresDB(context.Background(), o.Image, o.InitSQLScript)
+	dbContainer, err := setupPostgresDB(context.Background(), o.Version, o.InitSQLScript)
 	if err != nil {
 		it.T.Fatalf("database setup error: %v", err)
 	}
@@ -121,12 +121,12 @@ func (o IntegrationTestWithMocks) tearDown(it *IntegrationTest) {
 
 // IntegrationTestWithBigQuery is an option for integration testing that sets up a BigQuery database test container.
 type IntegrationTestWithBigQuery struct {
-	Image    string
+	Version  string
 	DataPath string
 }
 
 func (o IntegrationTestWithBigQuery) setup(it *IntegrationTest) {
-	container, err := setupBigqueryEmulator(context.Background(), o.Image, o.DataPath)
+	container, err := setupBigqueryEmulator(context.Background(), o.Version, o.DataPath)
 	if err != nil {
 		it.T.Fatalf("database setup error: %v", err)
 	}

--- a/echoprobe.go
+++ b/echoprobe.go
@@ -71,6 +71,7 @@ type IntegrationTestOption interface {
 // In the InitSQLScript a SQL script filename can be passed to initialize the database. The script should be located
 // under a 'fixtures' directory where the _test.go file is located. An optional gorm config can also be passed.
 type IntegrationTestWithPostgres struct {
+	Image         string
 	InitSQLScript string
 	Config        *gorm.Config
 }
@@ -81,7 +82,7 @@ func (o IntegrationTestWithPostgres) setup(it *IntegrationTest) {
 		o.Config = &gorm.Config{}
 	}
 
-	dbContainer, err := setupPostgresDB(context.Background(), o.InitSQLScript)
+	dbContainer, err := setupPostgresDB(context.Background(), o.Image, o.InitSQLScript)
 	if err != nil {
 		it.T.Fatalf("database setup error: %v", err)
 	}
@@ -120,11 +121,12 @@ func (o IntegrationTestWithMocks) tearDown(it *IntegrationTest) {
 
 // IntegrationTestWithBigQuery is an option for integration testing that sets up a BigQuery database test container.
 type IntegrationTestWithBigQuery struct {
+	Image    string
 	DataPath string
 }
 
 func (o IntegrationTestWithBigQuery) setup(it *IntegrationTest) {
-	container, err := setupBigqueryEmulator(context.Background(), o.DataPath)
+	container, err := setupBigqueryEmulator(context.Background(), o.Image, o.DataPath)
 	if err != nil {
 		it.T.Fatalf("database setup error: %v", err)
 	}

--- a/postgresql.go
+++ b/postgresql.go
@@ -27,11 +27,11 @@ import (
 )
 
 const (
-	defaultPostgresImage = "postgres:17-alpine"
-	dbName               = "postgres"
-	dbUsername            = "postgres"
-	dbPassword           = "password"
-	dbPort               = "5432/tcp"
+	defaultPostgresVersion = "17-alpine"
+	dbName                 = "postgres"
+	dbUsername             = "postgres"
+	dbPassword             = "password"
+	dbPort                 = "5432/tcp"
 )
 
 // PostgresDBContainer holds all the necessary information for postgres database test container.
@@ -46,13 +46,13 @@ type PostgresDBContainer struct {
 }
 
 // setupPostgresDB sets up a postgres database test container.
-func setupPostgresDB(ctx context.Context, image string, initSQLScript ...string) (*PostgresDBContainer, error) {
-	if image == "" {
-		image = defaultPostgresImage
+func setupPostgresDB(ctx context.Context, version string, initSQLScript ...string) (*PostgresDBContainer, error) {
+	if version == "" {
+		version = defaultPostgresVersion
 	}
 
 	req := testcontainers.ContainerRequest{
-		Image: image,
+		Image: "postgres:" + version,
 		Env: map[string]string{
 			"POSTGRES_USER":     dbUsername,
 			"POSTGRES_PASSWORD": dbPassword,

--- a/postgresql.go
+++ b/postgresql.go
@@ -27,10 +27,11 @@ import (
 )
 
 const (
-	dbName     = "postgres"
-	dbUsername = "postgres"
-	dbPassword = "password"
-	dbPort     = "5432/tcp"
+	defaultPostgresImage = "postgres:17-alpine"
+	dbName               = "postgres"
+	dbUsername            = "postgres"
+	dbPassword           = "password"
+	dbPort               = "5432/tcp"
 )
 
 // PostgresDBContainer holds all the necessary information for postgres database test container.
@@ -45,9 +46,13 @@ type PostgresDBContainer struct {
 }
 
 // setupPostgresDB sets up a postgres database test container.
-func setupPostgresDB(ctx context.Context, initSQLScript ...string) (*PostgresDBContainer, error) {
+func setupPostgresDB(ctx context.Context, image string, initSQLScript ...string) (*PostgresDBContainer, error) {
+	if image == "" {
+		image = defaultPostgresImage
+	}
+
 	req := testcontainers.ContainerRequest{
-		Image: "postgres:latest",
+		Image: image,
 		Env: map[string]string{
 			"POSTGRES_USER":     dbUsername,
 			"POSTGRES_PASSWORD": dbPassword,


### PR DESCRIPTION
# One-line summary

Allow consumers to pin container image versions instead of using `latest`.

## Description

Both `IntegrationTestWithPostgres` and `IntegrationTestWithBigQuery` previously
hardcoded their container images (`postgres:latest` and
`ghcr.io/goccy/bigquery-emulator:latest`). This is risky because a new major
Postgres release (e.g. 17→18) can silently break consumers.

This PR adds a `Version` field to both structs. When left empty (zero value), it
defaults to `17-alpine` and `latest` respectively. The image name itself is an
internal detail — consumers only choose which version tag to use.

## Types of Changes

- New feature (non-breaking change which adds functionality)

## Tasks
- [x] Add `Version` field to `IntegrationTestWithPostgres` (default `17-alpine`)
- [x] Add `Version` field to `IntegrationTestWithBigQuery` (default `latest`)
- [x] Plumb version through `setupPostgresDB` and `setupBigqueryEmulator`
- [x] All tests and pre-commit pass

## Review
- [x] Tests

## Deployment Notes
Non-breaking — existing consumers that don't set `Version` get the same behavior
with a pinned default instead of `latest`.