### PR TITLE
fix: use log-based wait strategy for BigQuery emulator

### DIFF
--- a/bigquery.go
+++ b/bigquery.go
@@ -66,7 +66,8 @@ func setupBigqueryEmulator(ctx context.Context, version string, dataPath string)
 		ExposedPorts: []string{bqHttpPort, bqGrpcPort},
 		WaitingFor: wait.ForAll(
 			wait.ForListeningPort(bqGrpcPort),
-			wait.ForListeningPort(bqHttpPort),
+			// https://github.com/goccy/bigquery-emulator/blob/main/cmd/bigquery-emulator/main.go (SetListenCallback)
+			wait.ForLog("REST server listening"),
 		),
 	}
 


### PR DESCRIPTION
# One-line summary

Fix BigQuery emulator container readiness check to prevent EOF errors in CI.

## Description

`wait.ForListeningPort` only verifies TCP socket availability, which succeeds as soon as the kernel accepts connections. The BigQuery emulator's HTTP handler may not be fully initialized at that point, causing `EOF` errors on the first HTTP request in slower environments (e.g. GitHub Actions runners).

The emulator also returns HTTP 500 for unknown paths (including `/`), making `wait.ForHTTP` unreliable.

This replaces the TCP-only check with `wait.ForLog("REST server listening")` which waits for the emulator's own readiness signal emitted via [`SetListenCallback`](https://github.com/goccy/bigquery-emulator/blob/main/cmd/bigquery-emulator/main.go).

## Types of Changes

- Bug fix (non-breaking change which fixes an issue)

## Tasks
- [x] Replace `wait.ForListeningPort(bqHttpPort)` with `wait.ForLog("REST server listening")`
- [x] Verify build passes locally

## Review
- [x] Tests
- [x] CHANGELOG