### PR TITLE
fix: intercept HTTP before clients are created

### DIFF
--- a/mock.go
+++ b/mock.go
@@ -44,6 +44,7 @@ type Mock struct {
 
 // NewMock creates a new Mock
 func NewMock(baseURL string) *Mock {
+	gock.Intercept()
 	return &Mock{
 		baseURL: baseURL,
 	}

--- a/mock_test.go
+++ b/mock_test.go
@@ -1,0 +1,25 @@
+package echoprobe
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIntegrationTestWithMocksInterceptsClientsCreatedBeforeMocksAreLoaded(t *testing.T) {
+	it := NewIntegrationTest(t, IntegrationTestWithMocks{BaseURL: "http://echoprobe.invalid"})
+	t.Cleanup(it.TearDown)
+
+	client := &http.Client{Transport: http.DefaultTransport}
+	it.Mock.MockRequest(&MockConfig{
+		Method:     http.MethodGet,
+		UrlPath:    "/resource",
+		StatusCode: http.StatusNoContent,
+	})
+
+	resp, err := client.Get("http://echoprobe.invalid/resource")
+	require.NoError(t, err)
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+}


### PR DESCRIPTION
## Summary

- Enable gock interception when the mock environment is created.
- Ensure HTTP clients created before individual mocks are loaded use the mocked transport.
- Add regression coverage for the client-construction timing.

## Checklist

- [x] All tests pass — `go test ./... -count=1`
- [x] Lint/format/typecheck clean — `pre-commit run --files mock.go mock_test.go`